### PR TITLE
Fix Influxb port check

### DIFF
--- a/tests/smoke/smoke2.py
+++ b/tests/smoke/smoke2.py
@@ -216,7 +216,7 @@ def debug_influx(node, influx_user, influx_pass):
         print("[WARNING]: InfluxDB Python Package is not installed!")
         return 1
     fail = check_port(node, 8086)
-    fail |= check_port(node, 8090)
+    fail |= check_port(node, 8083)
     if fail:
         success = False
     try:


### PR DESCRIPTION
Make smoke2.py check ports 8086 and 8083.
Previously it was checking ports 8086 and 8090.
This worked with the Java implementations because
the Java API was opening port 8090 for the admin
interface. This does not work with the Python
implementations.
